### PR TITLE
Fix missing defaults

### DIFF
--- a/packages/huawei_solar_pees.yaml
+++ b/packages/huawei_solar_pees.yaml
@@ -438,9 +438,9 @@ template:
             {% else %}
               {% set lastlast = 0 %}
             {% endif %}
-            {% set last = states('sensor.energy_yield_total') | float %}
+            {% set last = states('sensor.energy_yield_total') | float(0) %}
             {% if last > 0 %}
-              {{ states('sensor.energy_yield_total', 'last') | float }}
+              {{ states('sensor.energy_yield_total', 'last') | float(0) }}
             {% endif %}
   - trigger:
       - platform: state


### PR DESCRIPTION
Fixes this error

```
2024-01-22 09:02:59.054 ERROR (MainThread) [homeassistant.helpers.sensor] Error rendering state template for sensor.battery_charge_yield_sale: ValueError: Template error: float got invalid input 'unavailable' when rendering template '{% if last is defined %}
  {% set lastlast = states('sensor.energy_yield_total', 'last') | float(0) %}
{% else %}
  {% set lastlast = 0 %}
{% endif %} {% set last = states('sensor.energy_yield_total') | float %} {% if last > 0 %}
  {{ states('sensor.energy_yield_total', 'last') | float }}
{% endif %}' but no default was specified
```