### PR TITLE
Huawei Solar - PEES

### DIFF
--- a/packages/huawei_solar_input.yaml
+++ b/packages/huawei_solar_input.yaml
@@ -1,8 +1,8 @@
 # ----------------------------------------
 # HUAWEI SOLAR INPUT - User Specific Input
 # ----------------------------------------
-# version:
-# branch: alpha-016_misc
+# version: v1.0.3
+# branch: main
 # domain: https://github.com/JensenNick/huawei_solar_pees
 # codeowner: Nick Jensen
 #

--- a/packages/huawei_solar_input.yaml
+++ b/packages/huawei_solar_input.yaml
@@ -1,8 +1,8 @@
 # ----------------------------------------
 # HUAWEI SOLAR INPUT - User Specific Input
 # ----------------------------------------
-# version: v1.0.2
-# branch: main
+# version:
+# branch: alpha-016_misc
 # domain: https://github.com/JensenNick/huawei_solar_pees
 # codeowner: Nick Jensen
 #

--- a/packages/huawei_solar_input.yaml
+++ b/packages/huawei_solar_input.yaml
@@ -139,6 +139,12 @@ input_number:
     max: 120000
     step: 0.01
     mode: box
+  ## Battery Charge Power
+  battery_charge_power:
+    name: "Battery Charge Power"
+    min: 0
+    max: 5
+    step: 0.01
   ## ------------
   ## Solar Panels
   panels_on_inverter_1:

--- a/packages/huawei_solar_pees.yaml
+++ b/packages/huawei_solar_pees.yaml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------
 # HUAWEI SOLAR PEES - Power, Energy and Economy Sensors
 # -----------------------------------------------------
-# version: v2.0.8
+# version: v2.1.0
 # branch: main
 # domain: https://github.com/JensenNick/huawei_solar_pees
 # codeowner: Nick Jensen

--- a/packages/huawei_solar_pees.yaml
+++ b/packages/huawei_solar_pees.yaml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------
 # HUAWEI SOLAR PEES - Power, Energy and Economy Sensors
 # -----------------------------------------------------
-# version: v2.0.7
+# version: v2.0.8
 # branch: main
 # domain: https://github.com/JensenNick/huawei_solar_pees
 # codeowner: Nick Jensen
@@ -20,7 +20,7 @@
 # - 'sensor.inverter_input_power' (from the Huawei Solar integration)
 # - 'sensor.inverter_input_power_2' (from the Huawei Solar integration)
 # - 'sensor.power_meter_active_power' (from the Huawei Solar integration)
-# - 'sensor.battery_charge_discharge_power' (from the Huawei Solar integration)
+# - 'sensor.batteries_charge_discharge_power' (from the Huawei Solar integration)
 #
 # The "Huawei Solar PEES package" will use the electricity price sensors from the
 # "Energi Data Service integration" by MTrab as default.
@@ -326,7 +326,7 @@ template:
         state_class: measurement
         state: >
           {{ (
-          states('sensor.battery_charge_discharge_power') | float(0)
+          states('sensor.batteries_charge_discharge_power') | float(0)
           , 0 ) | max }}
       - name: "Power Battery Discharge"
         unique_id: power_battery_discharge
@@ -335,7 +335,7 @@ template:
         state_class: measurement
         state: >
           {{ (
-          states('sensor.battery_charge_discharge_power') | float(0)
+          states('sensor.batteries_charge_discharge_power') | float(0)
           , 0 ) | min | abs }}
       - name: "Power House Load"
         unique_id: power_house_load
@@ -347,7 +347,7 @@ template:
           states('sensor.power_inverter_1_input') | float(0) +
           states('sensor.power_inverter_2_input') | float(0) -
           states('sensor.power_meter_active_power') | float(0) -
-          states('sensor.battery_charge_discharge_power') | float(0)
+          states('sensor.batteries_charge_discharge_power') | float(0)
           , 0 ) | max }}
       - name: "Power House Load Yield"
         unique_id: power_house_load_yield

--- a/release_notes/release_notes_v2.md
+++ b/release_notes/release_notes_v2.md
@@ -4,8 +4,7 @@
 
 ## Release Note / v2.1.0
 
-According to the current version (version 1.4.1) of the *"Huawei Solar Integration"* by wlcrs, the naming of `sensor.battery_charge_discharge_power` has been converted to `sensor.batteries_charge_discharge_power`. 
-> ❗**Please note. There is NO BACKWORD COMPATIBILITY.** ❗
+According to the current version (version 1.4.1) of the *"Huawei Solar Integration"* by wlcrs, the naming of the input sensor `sensor.battery_charge_discharge_power` has been converted to `sensor.batteries_charge_discharge_power`. There is no changes to the names provided by the *"Huawei Solar PEES package"*.
 
 Input number for the Battery Charge Power has been added to the *"huawei_solar_input.yaml"* file.
 

--- a/release_notes/release_notes_v2.md
+++ b/release_notes/release_notes_v2.md
@@ -2,6 +2,10 @@
 
 **Power, Energy and Economy Sensors**
 
+## Release Note / v2.1.0
+
+According to the current version (version 1.4.1) of the *"Huawei Solar Integration" by wlcrs, the naming of `sensor.battery_charge_discharge_power` has been converted to `sensor.batteries_charge_discharge_power`.
+
 ## Release Note / v2.0.7
 
 Support for the newly released *"Huawei Solar STAT package"*, including new weekly utility meters in the `huawei_solar_pees.yaml` file and minor changes to the "Input Card". No changes were made to the `huawei_solar_input.yaml` file.

--- a/release_notes/release_notes_v2.md
+++ b/release_notes/release_notes_v2.md
@@ -4,7 +4,10 @@
 
 ## Release Note / v2.1.0
 
-According to the current version (version 1.4.1) of the *"Huawei Solar Integration" by wlcrs, the naming of `sensor.battery_charge_discharge_power` has been converted to `sensor.batteries_charge_discharge_power`.
+According to the current version (version 1.4.1) of the *"Huawei Solar Integration"* by wlcrs, the naming of `sensor.battery_charge_discharge_power` has been converted to `sensor.batteries_charge_discharge_power`. 
+> ❗**Please note there is NO BACKWORD COMPATIBILITY.** ❗
+
+Input number for the Battery Charge Power has been added to the *"huawei_solar_input.yaml"* file.
 
 ## Release Note / v2.0.7
 

--- a/release_notes/release_notes_v2.md
+++ b/release_notes/release_notes_v2.md
@@ -5,7 +5,7 @@
 ## Release Note / v2.1.0
 
 According to the current version (version 1.4.1) of the *"Huawei Solar Integration"* by wlcrs, the naming of `sensor.battery_charge_discharge_power` has been converted to `sensor.batteries_charge_discharge_power`. 
-> ❗**Please note there is NO BACKWORD COMPATIBILITY.** ❗
+> ❗**Please note. There is NO BACKWORD COMPATIBILITY.** ❗
 
 Input number for the Battery Charge Power has been added to the *"huawei_solar_input.yaml"* file.
 


### PR DESCRIPTION
## Release Note / v2.1.0

According to the current version (version 1.4.1) of the *"Huawei Solar Integration"* by wlcrs, the naming of the input sensor `sensor.battery_charge_discharge_power` has been converted to `sensor.batteries_charge_discharge_power`. There is no changes to the names provided by the *"Huawei Solar PEES package"*.

Input number for the Battery Charge Power has been added to the *"huawei_solar_input.yaml"* file.