### PR TITLE
Small suggestion to update Max for input number for Battery Rated Capacity and Battery charge power 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.yaml": "home-assistant"
+    }
+}

--- a/packages/huawei_solar_pees_input.yaml
+++ b/packages/huawei_solar_pees_input.yaml
@@ -120,7 +120,7 @@ input_number:
   battery_rated_capacity:
     name: "Battery Rated Capacity (in kWh)"
     min: 5
-    max: 30
+    max: 42
     step: 5
   battery_efficiency_soc_trigger:
     name: "Battery Efficiency SOC Trigger (Recomended Set 50%)"
@@ -143,7 +143,7 @@ input_number:
   battery_charge_power:
     name: "Battery Charge Power"
     min: 0
-    max: 5
+    max: 10.5
     step: 0.01
   ## ------------
   ## Solar Panels


### PR DESCRIPTION
To new s7 series and to charge power to support 3x batteries (maybe this even should be higher)?