### PR TITLE
Input - Add LC0, MB0 and iStore Support

### DIFF
--- a/packages/huawei_solar_pees_input.yaml
+++ b/packages/huawei_solar_pees_input.yaml
@@ -145,14 +145,14 @@ template:
       - name: "Inverter #1 Model"
         unique_id: inverter_1_model
         state: >-
-          {{ device_attr("sensor.inverter_input_power","model") | regex_findall_index('(SUN\d+-\d+(KTL|K)-(L|LC|M|MB|MAP)\d)|(IS-HYB-\d+-[13]PH)', 0) | first }}
+          {{ device_attr("sensor.inverter_input_power","model") | regex_findall_index('(SUN\d+-\d+(KTL|K)-(L|LC|M|MB|MAP)\d)|(IS-HYB-\d+-[1|3]PH)', 0) | first }}
         availability: >-
           {{ states('sensor.inverter_input_power') not in ['unknown','unavailable','none'] }}
 
       - name: "Inverter #2 Model"
         unique_id: inverter_2_model
         state: >-
-          {{ device_attr("sensor.inverter_input_power_2","model") | regex_findall_index('(SUN\d+-\d+(KTL|K)-(L|LC|M|MB|MAP)\d)|(IS-HYB-\d+-[13]PH)', 0) | first }}
+          {{ device_attr("sensor.inverter_input_power_2","model") | regex_findall_index('(SUN\d+-\d+(KTL|K)-(L|LC|M|MB|MAP)\d)|(IS-HYB-\d+-[1|3]PH)', 0) | first }}
         availability: >
           {{ states('sensor.inverter_input_power_2') not in ['unknown','unavailable','none'] }}
 

--- a/packages/huawei_solar_pees_input.yaml
+++ b/packages/huawei_solar_pees_input.yaml
@@ -148,49 +148,72 @@ template:
         unique_id: inverter_1_rated_power
         unit_of_measurement: W
         state: >
-          {% if '2KTL' in states('sensor.inverter_1_model') %}
+          {% set inverter_model = states('sensor.inverter_1_model') %}
+          {% if '2KTL' in inverter_model or '2000' in inverter_model %}
             {{ 2000 }}
-          {% elif '3KTL' in states('sensor.inverter_1_model') %}
+          {% elif '3KTL' in inverter_model or '3000' in inverter_model %}
             {{ 3000 }}
-          {% elif '3-68KTL' in states('sensor.inverter_1_model') %}
+          {% elif '3-68KTL' in inverter_model or '3680' in inverter_model %}
             {{ 3680 }}
-          {% elif '4KTL' in states('sensor.inverter_1_model') %}
+          {% elif '4KTL' in inverter_model or '4000' in inverter_model %}
             {{ 4000 }}
-          {% elif '4-6KTL' in states('sensor.inverter_1_model') %}
+          {% elif '4-6KTL' in inverter_model or '4600' in inverter_model %}
             {{ 4600 }}
-          {% elif '5KTL' in states('sensor.inverter_1_model') %}
+          {% elif '5KTL' in inverter_model or '5000' in inverter_model %}
             {{ 5000 }}
-          {% elif '6KTL' in states('sensor.inverter_1_model') %}
+          {% elif '6KTL' in inverter_model or '6000' in inverter_model %}
             {{ 6000 }}
-          {% elif '8KTL' in states('sensor.inverter_1_model') %}
+          {% elif '8KTL' in inverter_model or '8K' in inverter_model or '8000' in inverter_model %}
             {{ 8000 }}
-          {% elif '10KTL' in states('sensor.inverter_1_model') %}
+          {% elif '10KTL' in inverter_model or '10000' in inverter_model %}
             {{ 10000 }}
+          {% elif '12K' in inverter_model or '12000' in inverter_model %}
+            {{ 12000 }}
+          {% elif '15K' in inverter_model or '15000' in inverter_model %}
+            {{ 15000 }}
+          {% elif '17K' in inverter_model or '17000' in inverter_model %}
+            {{ 17000 }}
+          {% elif '20K' in inverter_model or '20000' in inverter_model %}
+            {{ 20000 }}
+          {% elif '25K' in inverter_model or '25000' in inverter_model %}
+            {{ 25000 }}
           {% endif %}
         availability: >
           {{ states('sensor.inverter_1_model') not in ['unknown','unavailable','none'] }}
+
       - name: "Inverter #2 Rated Power"
         unique_id: inverter_2_rated_power
         unit_of_measurement: W
         state: >
-          {% if '2KTL' in states('sensor.inverter_2_model') %}
+          {% set inverter_model = states('sensor.inverter_2_model') %}
+          {% if '2KTL' in inverter_model or '2000' in inverter_model %}
             {{ 2000 }}
-          {% elif '3KTL' in states('sensor.inverter_2_model') %}
+          {% elif '3KTL' in inverter_model or '3000' in inverter_model %}
             {{ 3000 }}
-          {% elif '3-68KTL' in states('sensor.inverter_2_model') %}
+          {% elif '3-68KTL' in inverter_model or '3680' in inverter_model %}
             {{ 3680 }}
-          {% elif '4KTL' in states('sensor.inverter_2_model') %}
+          {% elif '4KTL' in inverter_model or '4000' in inverter_model %}
             {{ 4000 }}
-          {% elif '4-6KTL' in states('sensor.inverter_2_model') %}
+          {% elif '4-6KTL' in inverter_model or '4600' in inverter_model %}
             {{ 4600 }}
-          {% elif '5KTL' in states('sensor.inverter_2_model') %}
+          {% elif '5KTL' in inverter_model or '5000' in inverter_model %}
             {{ 5000 }}
-          {% elif '6KTL' in states('sensor.inverter_2_model') %}
+          {% elif '6KTL' in inverter_model or '6000' in inverter_model %}
             {{ 6000 }}
-          {% elif '8KTL' in states('sensor.inverter_2_model') %}
+          {% elif '8KTL' in inverter_model or '8K' in inverter_model or '8000' in inverter_model %}
             {{ 8000 }}
-          {% elif '10KTL' in states('sensor.inverter_2_model') %}
-            {{ 10000 }}
+          {% elif '10KTL' in inverter_model or '10K' in inverter_model or '8000' in inverter_model %}
+            {{ 8000 }}
+          {% elif '12K' in inverter_model or '12000' in inverter_model %}
+            {{ 12000 }}
+          {% elif '15K' in inverter_model or '15000' in inverter_model %}
+            {{ 15000 }}
+          {% elif '17K' in inverter_model or '17000' in inverter_model %}
+            {{ 17000 }}
+          {% elif '20K' in inverter_model or '20000' in inverter_model %}
+            {{ 20000 }}
+          {% elif '25K' in inverter_model or '25000' in inverter_model %}
+            {{ 25000 }}
           {% endif %}
         availability: >
           {{ states('sensor.inverter_2_model') not in ['unknown','unavailable','none'] }}

--- a/packages/huawei_solar_pees_input.yaml
+++ b/packages/huawei_solar_pees_input.yaml
@@ -31,6 +31,7 @@
 input_boolean:
   efficiency_corrected_power_input:
     name: "Efficiency Corrected Power Input"
+
 # ------------
 # INPUT NUMBER
 # ------------
@@ -42,16 +43,19 @@ input_number:
     min: 90
     max: 560
     step: 5
+
   inverter_1_operating_voltage_m1:
     name: "Inverter #1 Operating Voltage M1"
     min: 140
     max: 980
     step: 5
+
   inverter_1_overall_factor:
     name: "Inverter #1 Overall Factor"
     min: 98
     max: 102
     step: 0.2
+
   ## --------------------
   ## Inverter #2 Settings
   inverter_2_operating_voltage_l1:
@@ -59,16 +63,19 @@ input_number:
     min: 90
     max: 560
     step: 5
+
   inverter_2_operating_voltage_m1:
     name: "Inverter #2 Operating Voltage M1"
     min: 140
     max: 980
     step: 5
+
   inverter_2_overall_factor:
     name: "Inverter #2 Overall Factor"
     min: 98
     max: 102
     step: 0.2
+
 # ----------
 # INPUT TEXT
 # ----------
@@ -79,6 +86,7 @@ input_text:
     name: "Electricity Price Import (Energi Data Service by Default)"
   electricity_price_export:
     name: "Electricity Price Export (Energi Data Service - Sale by Default)"
+
 # ---------------
 # TEMPLATE SENSOR
 # ---------------
@@ -94,6 +102,7 @@ template:
         unique_id: inverter_1_is_m1
         state: >
           {{ 'M1' in states('sensor.inverter_1_model') }}
+  
       ## -------------------
       ## Inverter 2 is model
       - name: "Inverter 2 is L1"
@@ -104,6 +113,7 @@ template:
         unique_id: inverter_2_is_m1
         state: >
           {{ 'M1' in states('sensor.inverter_2_model') }}
+
   - sensor:
       ## --------------------------------------
       ## Electricity Price for Energy Dashboard
@@ -112,6 +122,7 @@ template:
         unit_of_measurement: DKK/kWh
         state: >
           {{ states('sensor.energi_data_service') | float(0) * (-1) }}
+
       ## ----------------------------
       ## Tariff on Electricity Export
       - name: "Tariff Export"
@@ -128,20 +139,23 @@ template:
             konstant_indfoedningstarif + 
             jyskenergi_balancetarif 
             ) / 100 }}
+
       ## --------------
       ## Inverter Model
       - name: "Inverter #1 Model"
         unique_id: inverter_1_model
         state: >-
-          {{ device_attr("sensor.inverter_input_power","model") | regex_findall_index('(SUN\d+-\d+KTL-[L|M|MB]\d+)|(IS-HYB-\d-\[1|3]PH)', 0) | first }}
+          {{ device_attr("sensor.inverter_input_power","model") | regex_findall_index('(SUN\d+-\d+(KTL|K)-(L|LC|M|MB|MAP)\d)|(IS-HYB-\d+-[13]PH)', 0) | first }}
         availability: >-
           {{ states('sensor.inverter_input_power') not in ['unknown','unavailable','none'] }}
+
       - name: "Inverter #2 Model"
         unique_id: inverter_2_model
         state: >-
-          {{ device_attr("sensor.inverter_input_power_2","model") | regex_findall_index('(SUN\d+-\d+KTL-[L|M|MB]\d+)|(IS-HYB-\d-\[1|3]PH)', 0) | first }}
+          {{ device_attr("sensor.inverter_input_power_2","model") | regex_findall_index('(SUN\d+-\d+(KTL|K)-(L|LC|M|MB|MAP)\d)|(IS-HYB-\d+-[13]PH)', 0) | first }}
         availability: >
           {{ states('sensor.inverter_input_power_2') not in ['unknown','unavailable','none'] }}
+
       ## --------------------
       ## Inverter Rated Power
       - name: "Inverter #1 Rated Power"


### PR DESCRIPTION
1) Add support for iStore inverters, that list the full capacity (W) in the name, i.e. 10000 (not 10K or 10KTL)

2) Add support for Huawei LC0 inverters, that list their capacity in the model name as 8K and 10K

3) Add support for Huawei MB0 inverters, that list their capacity in the model name as 10K, 12K, 15K, 17K, 20K or 25K.

4) Updated inverter_rated_power sensor to use 'set inverter_model =' that then references to sensor to query. This saves referring to the specific sensor 30 times in the state formula, as well as being able to update the sensor to refer to at one point, that updates the whole sensor.

5) Update inverter_model state string/formula to support newer model inverters, this regex will match (for example):

Huawei:
    SUN2000-5KTL-L0
    SUN2000-6KTL-L1
    SUN2000-8KTL-LC0
    SUN2000-5KTL-M0
    SUN2000-6KTL-M1
    SUN2000-8KTL-M2
    SUN2000-12KTL-M3
    SUN2000-15K-MAP0
    SUN2000-17K-MB0
iStore:
    IS-HYB-10000-1PH
    IS-HYB-15000-3PH