### PR TITLE
Update huawei_solar_pees_input.yaml - Fix Error

### DIFF
--- a/packages/huawei_solar_pees_input.yaml
+++ b/packages/huawei_solar_pees_input.yaml
@@ -187,13 +187,13 @@ template:
       - name: "Inverter #1 Model"
         unique_id: inverter_1_model
         state: >-
-          {{ device_attr("sensor.inverter_input_power","model") | regex_findall_index('(SUN\d+-\d+(KTL|K)-(-L|-LC|-M|-MB|-MAP)\d)|(IS-HYB-\d+-[1|3]PH)', 0) | first }}
+          {{ device_attr("sensor.inverter_input_power","model") | regex_findall_index('(SUN\d+-\d+(KTL|K)(-L|-LC|-M|-MB|-MAP)\d)|(IS-HYB-\d+-[1|3]PH)', 0) | first }}
         availability: >-
           {{ states('sensor.inverter_input_power') not in ['unknown','unavailable','none'] }}
       - name: "Inverter #2 Model"
         unique_id: inverter_2_model
         state: >-
-          {{ device_attr("sensor.inverter_input_power_2","model") | regex_findall_index('(SUN\d+-\d+(KTL|K)-(-L|-LC|-M|-MB|-MAP)\d)|(IS-HYB-\d+-[1|3]PH)', 0) | first }}
+          {{ device_attr("sensor.inverter_input_power_2","model") | regex_findall_index('(SUN\d+-\d+(KTL|K)(-L|-LC|-M|-MB|-MAP)\d)|(IS-HYB-\d+-[1|3]PH)', 0) | first }}
         availability: >
           {{ states('sensor.inverter_input_power_2') not in ['unknown','unavailable','none'] }}
       ## --------------------


### PR DESCRIPTION
When you added '-' in front of all the -L / -M etc, you need to delete this one that sits between the 'KTL' and 'L0 etc', or else you end up with the regex looking for '--L1' etc.