### PR TITLE
update inverter name sensors to avoid duplicates

### DIFF
--- a/packages/huawei_solar_pees_input.yaml
+++ b/packages/huawei_solar_pees_input.yaml
@@ -150,12 +150,12 @@ template:
         unique_id: inverter_2_is_m1
         state: >
           {{ states('sensor.inverter_2_model') | regex_search('-M1|-5000-3PH|-6000-3PH') }}
-      - name: "Inverter 1 is MAP0"
-        unique_id: inverter_1_is_map0
+      - name: "Inverter 2 is MAP0"
+        unique_id: inverter_2_is_map0
         state: >
           {{ states('sensor.inverter_2_model') | regex_search('-MAP0') }}
-      - name: "Inverter 1 is MB0"
-        unique_id: inverter_1_is_mb0
+      - name: "Inverter 2 is MB0"
+        unique_id: inverter_2_is_mb0
         state: >
           {{ states('sensor.inverter_2_model') | regex_search('-MB0|-10000-3PH|-12000-3PH|-15000-3PH|-17000-3PH|-20000-3PH|-25000-3PH') }}
   - sensor:


### PR DESCRIPTION
Hi,
It looks like Inverter 1 names were used in Inverter 2 sensors section causing duplicates errors.

```
Logger: homeassistant.components.binary_sensor
Source: helpers/entity_platform.py:843
integration: Binary sensor (documentation, issues)
First occurred: 09:19:50 (2 occurrences)
Last logged: 09:19:50

Platform template does not generate unique IDs. ID inverter_1_is_map0 already exists - ignoring binary_sensor.inverter_1_is_map0
Platform template does not generate unique IDs. ID inverter_1_is_mb0 already exists - ignoring binary_sensor.inverter_1_is_mb0
```